### PR TITLE
Let zionbuilder.pot keep its name!

### DIFF
--- a/packages/zionbuilder-service/lib/commands/translate.js
+++ b/packages/zionbuilder-service/lib/commands/translate.js
@@ -8,7 +8,7 @@ module.exports = (options, args) => {
 
     const config = {
         slug: name,
-        packageName: titleCase( name.replace("-", " ") ),
+        packageName: name.replace("-", " "),
         reportBugsUrl: '',
         team: '',
         ...service.options.getOption('l10n')


### PR DESCRIPTION
Makes https://github.com/zionbuilder/zionbuilder/pull/49 succeed